### PR TITLE
feat(auth): email verification flow\n- Prisma: add emailVerified, ema…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.0",
         "express": "^4.18.2",
+        "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "nodemailer": "^6.9.11",
         "prisma": "^5.8.0"
       },
       "devDependencies": {
@@ -697,6 +699,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1195,6 +1210,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1455,6 +1476,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -2113,6 +2143,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "prisma": "^5.8.0",
-    "@prisma/client": "^5.8.0"
+    "@prisma/client": "^5.8.0",
+    "nodemailer": "^6.9.11",
+    "express-validator": "^7.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,9 @@ model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique
   password  String
+  emailVerified          Boolean?  @default(false)
+  emailVerificationToken String?   @unique
+  emailVerificationExpires DateTime?
   portfolios Portfolio[]
   watchlistItems UserWatchlist[]
 }

--- a/src/config/nodemailer.js
+++ b/src/config/nodemailer.js
@@ -1,0 +1,29 @@
+import nodemailer from "nodemailer";
+
+const host = process.env.SMTP_HOST;
+const port = Number(process.env.SMTP_PORT || 587);
+const user = process.env.SMTP_USER;
+const pass = process.env.SMTP_PASSWORD;
+
+if (!host || !user || !pass) {
+  // Do not throw on import; services that send will validate later.
+  // This allows the app to boot even if email is not configured in some envs.
+  console.warn("[mail] SMTP credentials not fully configured");
+}
+
+export const mailTransport = nodemailer.createTransport({
+  host,
+  port,
+  secure: port === 465,
+  auth: user && pass ? { user, pass } : undefined,
+});
+
+export async function verifyMailTransport() {
+  try {
+    await mailTransport.verify();
+    return true;
+  } catch (e) {
+    console.warn("[mail] transport verify failed:", e.message);
+    return false;
+  }
+}

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,31 +1,114 @@
 import express from "express";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
+import crypto from "crypto";
 import { PrismaClient } from "@prisma/client";
+import { body, validationResult } from "express-validator";
+import { mailTransport } from "../config/nodemailer.js";
 
 const router = express.Router();
 const prisma = new PrismaClient();
 
-router.post("/register", async (req, res) => {
-  try {
-    const { email, password } = req.body;
-    const hashed = await bcrypt.hash(password, 10);
+router.post(
+  "/register",
+  [
+    body("email").isEmail().normalizeEmail(),
+    body("password").isString().isLength({ min: 8 }),
+  ],
+  async (req, res) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ error: "Invalid input", details: errors.array() });
+      }
 
-    const user = await prisma.user.create({
-      data: { email, password: hashed },
-    });
+      const { email, password } = req.body;
 
-    res.json({ message: "User registered", user });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
+      const existing = await prisma.user.findUnique({ where: { email } });
+      if (existing) return res.status(400).json({ error: "Email already registered" });
+
+      const hashed = await bcrypt.hash(password, 10);
+      const token = crypto.randomBytes(32).toString("hex");
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+      const user = await prisma.user.create({
+        data: {
+          email,
+          password: hashed,
+          emailVerified: false,
+          emailVerificationToken: token,
+          emailVerificationExpires: expiresAt,
+        },
+        select: { id: true, email: true, emailVerified: true },
+      });
+
+      const from = process.env.EMAIL_FROM_ADDRESS;
+      const frontendUrl = process.env.FRONTEND_URL || "";
+      const verifyUrl = `${String(frontendUrl).replace(/\/$/, "")}/verify-email?token=${token}`;
+
+      try {
+        await mailTransport.sendMail({
+          from,
+          to: email,
+          subject: "Verify your Finnacle email",
+          html: `<p>Welcome to Finnacle!</p><p>Please verify your email by clicking the link below:</p><p><a href="${verifyUrl}">Verify Email</a></p><p>This link expires in 1 hour.</p>`,
+        });
+      } catch (e) {
+        // If email fails, we still keep the user record; client can retry verification
+        console.warn("[mail] send failed:", e.message);
+      }
+
+      return res.status(201).json({ message: "Verification email sent" });
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
   }
-});
+);
+
+router.post(
+  "/verify-email",
+  [body("token").isString().isLength({ min: 10 })],
+  async (req, res) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ error: "Invalid token" });
+      }
+
+      const { token } = req.body;
+      const user = await prisma.user.findFirst({
+        where: {
+          emailVerificationToken: token,
+          emailVerificationExpires: { gt: new Date() },
+        },
+      });
+      if (!user) return res.status(400).json({ error: "Invalid or expired token" });
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          emailVerified: true,
+          emailVerificationToken: null,
+          emailVerificationExpires: null,
+        },
+      });
+
+      return res.json({ message: "Email verified" });
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
+  }
+);
 
 router.post("/login", async (req, res) => {
   try {
     const { email, password } = req.body;
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) return res.status(400).json({ error: "Invalid email or password" });
+
+    if (!user.emailVerified) {
+      return res.status(403).json({ error: "Email not verified" });
+    }
 
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(400).json({ error: "Invalid email or password" });


### PR DESCRIPTION
…ilVerificationToken(unique), emailVerificationExpires\n- Register: validate input, create user with token + expiry, send Brevo SMTP email via nodemailer\n- Verify: POST /api/auth/verify-email to confirm token and mark verified\n- Login: block unverified accounts (403)\n- Deps: add nodemailer, express-validator; config: src/config/nodemailer.js